### PR TITLE
fix(onboarding): theme-aware colors and animated brand pattern

### DIFF
--- a/zuralog/lib/features/onboarding/presentation/onboarding_flow_screen.dart
+++ b/zuralog/lib/features/onboarding/presentation/onboarding_flow_screen.dart
@@ -380,9 +380,9 @@ class _OnboardingFlowScreenState extends ConsumerState<OnboardingFlowScreen> {
         children: [
           const Positioned.fill(
             child: ZPatternOverlay(
-              variant: ZPatternVariant.original,
+              variant: ZPatternVariant.sage,
               opacity: 0.10,
-              blendMode: BlendMode.screen,
+              animate: true,
             ),
           ),
           Column(
@@ -437,6 +437,8 @@ class _OnboardingTopBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return Padding(
       padding: const EdgeInsets.fromLTRB(
         AppDimens.spaceSm,
@@ -452,7 +454,7 @@ class _OnboardingTopBar extends StatelessWidget {
             child: onBack != null
                 ? IconButton(
                     icon: const Icon(Icons.arrow_back_ios_new_rounded, size: 20),
-                    color: AppColors.textSecondaryDark,
+                    color: colors.textSecondary,
                     onPressed: onBack,
                     tooltip: 'Back',
                     padding: EdgeInsets.zero,
@@ -476,7 +478,7 @@ class _OnboardingTopBar extends StatelessWidget {
                 ? TextButton(
                     onPressed: onSkip,
                     style: TextButton.styleFrom(
-                      foregroundColor: AppColors.textSecondaryDark,
+                      foregroundColor: colors.textSecondary,
                       minimumSize: Size.zero,
                       tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                       padding: const EdgeInsets.symmetric(

--- a/zuralog/lib/features/onboarding/presentation/steps/connect_apps_step.dart
+++ b/zuralog/lib/features/onboarding/presentation/steps/connect_apps_step.dart
@@ -82,6 +82,8 @@ class ConnectAppsStep extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(
         AppDimens.spaceLg,
@@ -96,7 +98,7 @@ class ConnectAppsStep extends StatelessWidget {
           Text(
             'Connect your\napps & devices',
             style: AppTextStyles.displayLarge.copyWith(
-              color: AppColors.primary,
+              color: colors.primary,
               height: 1.15,
             ),
           ),
@@ -105,7 +107,7 @@ class ConnectAppsStep extends StatelessWidget {
             'Zuralog works best with your existing health apps. '
             'Connect them now or any time from Settings.',
             style: AppTextStyles.bodyLarge
-                .copyWith(color: AppColors.textSecondaryDark),
+                .copyWith(color: colors.textSecondary),
           ),
 
           const SizedBox(height: AppDimens.spaceXl),
@@ -118,7 +120,7 @@ class ConnectAppsStep extends StatelessWidget {
               crossAxisCount: 2,
               mainAxisSpacing: AppDimens.spaceMd,
               crossAxisSpacing: AppDimens.spaceMd,
-              childAspectRatio: 1.0,
+              childAspectRatio: 0.9,
             ),
             itemCount: _featuredApps.length,
             itemBuilder: (context, index) =>
@@ -131,14 +133,14 @@ class ConnectAppsStep extends StatelessWidget {
           Container(
             padding: const EdgeInsets.all(AppDimens.spaceMd),
             decoration: BoxDecoration(
-              color: AppColors.primary.withValues(alpha: 0.08),
+              color: colors.primary.withValues(alpha: 0.08),
               borderRadius: BorderRadius.circular(AppDimens.shapeSm),
             ),
             child: Row(
               children: [
-                const Icon(
+                Icon(
                   Icons.info_outline_rounded,
-                  color: AppColors.primary,
+                  color: colors.primary,
                   size: AppDimens.iconSm,
                 ),
                 const SizedBox(width: AppDimens.spaceSm),
@@ -146,7 +148,7 @@ class ConnectAppsStep extends StatelessWidget {
                   child: Text(
                     '45+ apps supported via Apple Health and Google Health Connect.',
                     style: AppTextStyles.bodySmall
-                        .copyWith(color: AppColors.textSecondaryDark),
+                        .copyWith(color: colors.textSecondary),
                   ),
                 ),
               ],
@@ -168,10 +170,12 @@ class _IntegrationTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return Container(
       padding: const EdgeInsets.all(AppDimens.spaceMd),
       decoration: BoxDecoration(
-        color: AppColors.surface,
+        color: colors.surface,
         borderRadius: BorderRadius.circular(AppDimens.shapeMd),
       ),
       child: Column(
@@ -193,7 +197,7 @@ class _IntegrationTile extends StatelessWidget {
               Text(
                 app.name,
                 style: AppTextStyles.titleMedium
-                    .copyWith(color: AppColors.textPrimaryDark),
+                    .copyWith(color: colors.textPrimary),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
@@ -201,7 +205,7 @@ class _IntegrationTile extends StatelessWidget {
               Text(
                 app.description,
                 style: AppTextStyles.bodyMedium
-                    .copyWith(color: AppColors.textSecondaryDark),
+                    .copyWith(color: colors.textSecondary),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
               ),
@@ -217,13 +221,13 @@ class _IntegrationTile extends StatelessWidget {
                 vertical: 4,
               ),
               decoration: BoxDecoration(
-                color: AppColors.primary.withValues(alpha: 0.12),
+                color: colors.primary.withValues(alpha: 0.12),
                 borderRadius: BorderRadius.circular(AppDimens.shapePill),
               ),
               child: Text(
                 'Later',
                 style: AppTextStyles.bodySmall.copyWith(
-                  color: AppColors.primary,
+                  color: colors.primary,
                   fontWeight: FontWeight.w600,
                 ),
               ),

--- a/zuralog/lib/features/onboarding/presentation/steps/discovery_step.dart
+++ b/zuralog/lib/features/onboarding/presentation/steps/discovery_step.dart
@@ -48,6 +48,8 @@ class DiscoveryStep extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(
         AppDimens.spaceLg,
@@ -62,7 +64,7 @@ class DiscoveryStep extends StatelessWidget {
           Text(
             'One last thing',
             style: AppTextStyles.displayLarge.copyWith(
-              color: AppColors.primary,
+              color: colors.primary,
               height: 1.15,
             ),
           ),
@@ -70,7 +72,7 @@ class DiscoveryStep extends StatelessWidget {
           Text(
             'Where did you hear about Zuralog?',
             style: AppTextStyles.bodyLarge
-                .copyWith(color: AppColors.textSecondaryDark),
+                .copyWith(color: colors.textSecondary),
           ),
 
           const SizedBox(height: AppDimens.spaceXl),
@@ -100,7 +102,7 @@ class DiscoveryStep extends StatelessWidget {
           Text(
             'This is optional — tap Finish to complete setup.',
             style: AppTextStyles.bodySmall
-                .copyWith(color: AppColors.textSecondaryDark),
+                .copyWith(color: colors.textSecondary),
           ),
           const SizedBox(height: AppDimens.spaceLg),
         ],
@@ -125,6 +127,8 @@ class _SourceTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return ZSelectableTile(
       isSelected: isSelected,
       onTap: onTap,
@@ -140,15 +144,15 @@ class _SourceTile extends StatelessWidget {
             decoration: BoxDecoration(
               shape: BoxShape.circle,
               border: Border.all(
-                color: isSelected ? AppColors.primary : AppColors.textSecondaryDark,
+                color: isSelected ? colors.primary : colors.textSecondary,
                 width: isSelected ? 0 : 1.5,
               ),
-              color: isSelected ? AppColors.primary : const Color(0x00000000),
+              color: isSelected ? colors.primary : const Color(0x00000000),
             ),
             child: isSelected
-                ? const Icon(
+                ? Icon(
                     Icons.check_rounded,
-                    color: AppColors.primaryButtonText,
+                    color: colors.textOnSage,
                     size: 14,
                   )
                 : null,
@@ -159,8 +163,8 @@ class _SourceTile extends StatelessWidget {
               label,
               style: AppTextStyles.bodyLarge.copyWith(
                 color: isSelected
-                    ? AppColors.textPrimaryDark
-                    : AppColors.textSecondaryDark,
+                    ? colors.textPrimary
+                    : colors.textSecondary,
                 fontWeight:
                     isSelected ? FontWeight.w600 : FontWeight.normal,
               ),

--- a/zuralog/lib/features/onboarding/presentation/steps/fitness_level_step.dart
+++ b/zuralog/lib/features/onboarding/presentation/steps/fitness_level_step.dart
@@ -76,6 +76,8 @@ class FitnessLevelStep extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(
         AppDimens.spaceLg,
@@ -90,7 +92,7 @@ class FitnessLevelStep extends StatelessWidget {
           Text(
             'How active\nare you?',
             style: AppTextStyles.displayLarge.copyWith(
-              color: AppColors.primary,
+              color: colors.primary,
               height: 1.1,
             ),
           ),
@@ -98,7 +100,7 @@ class FitnessLevelStep extends StatelessWidget {
           Text(
             'Helps your AI coach calibrate recommendations.',
             style: AppTextStyles.bodyLarge.copyWith(
-              color: AppColors.textSecondaryDark,
+              color: colors.textSecondary,
             ),
           ),
 
@@ -148,6 +150,8 @@ class _FitnessLevelTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return ZSelectableTile(
       isSelected: isSelected,
       onTap: onTap,
@@ -161,16 +165,16 @@ class _FitnessLevelTile extends StatelessWidget {
             height: 44,
             decoration: BoxDecoration(
               color: isSelected
-                  ? AppColors.primary.withValues(alpha: 0.15)
-                  : AppColors.surfaceRaised,
+                  ? colors.primary.withValues(alpha: 0.15)
+                  : colors.surfaceRaised,
               borderRadius: BorderRadius.circular(AppDimens.shapeSm),
             ),
             child: Icon(
               level.icon,
               size: 22,
               color: isSelected
-                  ? AppColors.primary
-                  : AppColors.textSecondaryDark,
+                  ? colors.primary
+                  : colors.textSecondary,
             ),
           ),
 
@@ -185,15 +189,15 @@ class _FitnessLevelTile extends StatelessWidget {
                   level.title,
                   style: AppTextStyles.titleMedium.copyWith(
                     color: isSelected
-                        ? AppColors.primary
-                        : AppColors.textPrimaryDark,
+                        ? colors.primary
+                        : colors.textPrimary,
                   ),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   level.subtitle,
                   style: AppTextStyles.bodyMedium.copyWith(
-                    color: AppColors.textSecondaryDark,
+                    color: colors.textSecondary,
                   ),
                 ),
               ],

--- a/zuralog/lib/features/onboarding/presentation/steps/goals_step.dart
+++ b/zuralog/lib/features/onboarding/presentation/steps/goals_step.dart
@@ -19,13 +19,13 @@ class _Goal {
   const _Goal({
     required this.id,
     required this.label,
-    required this.emoji,
+    required this.icon,
     required this.color,
   });
 
   final String id;
   final String label;
-  final String emoji;
+  final IconData icon;
 
   /// Health category color for the selected state.
   final Color color;
@@ -36,50 +36,50 @@ const List<_Goal> _goals = [
   _Goal(
     id: 'lose_weight',
     label: 'Lose weight',
-    emoji: '⚖️',
+    icon: Icons.monitor_weight_outlined,
     color: AppColors.categoryBody,
   ),
   _Goal(
     id: 'build_muscle',
     label: 'Build muscle',
-    emoji: '💪',
+    icon: Icons.fitness_center_rounded,
     color: AppColors.categoryActivity,
   ),
   _Goal(
     id: 'sleep_better',
     label: 'Sleep better',
-    emoji: '😴',
+    icon: Icons.bedtime_outlined,
     color: AppColors.categorySleep,
   ),
   _Goal(
     id: 'improve_fitness',
     label: 'Improve fitness',
-    emoji: '🏃',
+    icon: Icons.directions_run_rounded,
     color: AppColors.categoryActivity,
   ),
   _Goal(
     id: 'reduce_stress',
     label: 'Reduce stress',
-    emoji: '🧘',
+    icon: Icons.self_improvement_rounded,
     color: AppColors.categoryWellness,
   ),
   _Goal(
     id: 'track_nutrition',
     label: 'Track nutrition',
-    emoji: '🥗',
+    icon: Icons.restaurant_rounded,
     color: AppColors.categoryNutrition,
   ),
   _Goal(
     id: 'heart_health',
     label: 'Heart health',
-    emoji: '❤️',
+    icon: Icons.favorite_outline_rounded,
     color: AppColors.categoryHeart,
   ),
   _Goal(
     id: 'general_wellness',
     label: 'General wellness',
-    emoji: '✨',
-    color: AppColors.categoryMobility,
+    icon: Icons.spa_outlined,
+    color: AppColors.categoryWellness,
   ),
 ];
 
@@ -207,7 +207,19 @@ class _GoalTile extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(goal.emoji, style: AppTextStyles.bodyLarge.copyWith(fontSize: 24)),
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: goal.color.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(AppDimens.shapeSm),
+            ),
+            child: Icon(
+              goal.icon,
+              size: 22,
+              color: goal.color,
+            ),
+          ),
           Text(
             goal.label,
             style: AppTextStyles.labelMedium.copyWith(

--- a/zuralog/lib/features/onboarding/presentation/steps/goals_step.dart
+++ b/zuralog/lib/features/onboarding/presentation/steps/goals_step.dart
@@ -115,6 +115,8 @@ class GoalsStep extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(
         AppDimens.spaceLg,
@@ -129,14 +131,14 @@ class GoalsStep extends StatelessWidget {
           Text(
             'What are your\nhealth goals?',
             style: AppTextStyles.displayLarge.copyWith(
-              color: AppColors.primary,
+              color: colors.primary,
               height: 1.15,
             ),
           ),
           const SizedBox(height: AppDimens.spaceSm),
           Text(
             'Select all that apply. You can change these later.',
-            style: AppTextStyles.bodyLarge.copyWith(color: AppColors.textSecondaryDark),
+            style: AppTextStyles.bodyLarge.copyWith(color: colors.textSecondary),
           ),
 
           const SizedBox(height: AppDimens.spaceXl),
@@ -168,7 +170,7 @@ class GoalsStep extends StatelessWidget {
             Text(
               'You can skip this — tap Next to continue.',
               style: AppTextStyles.bodySmall
-                  .copyWith(color: AppColors.textSecondaryDark),
+                  .copyWith(color: colors.textSecondary),
             ),
           const SizedBox(height: AppDimens.spaceLg),
         ],
@@ -193,6 +195,8 @@ class _GoalTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return ZSelectableTile(
       isSelected: isSelected,
       onTap: onTap,
@@ -207,7 +211,7 @@ class _GoalTile extends StatelessWidget {
           Text(
             goal.label,
             style: AppTextStyles.labelMedium.copyWith(
-              color: isSelected ? goal.color : AppColors.textPrimaryDark,
+              color: isSelected ? goal.color : colors.textPrimary,
               fontWeight:
                   isSelected ? FontWeight.w600 : FontWeight.w500,
             ),

--- a/zuralog/lib/features/onboarding/presentation/steps/goals_step.dart
+++ b/zuralog/lib/features/onboarding/presentation/steps/goals_step.dart
@@ -79,7 +79,7 @@ const List<_Goal> _goals = [
     id: 'general_wellness',
     label: 'General wellness',
     emoji: '✨',
-    color: AppColors.primary,
+    color: AppColors.categoryMobility,
   ),
 ];
 
@@ -211,7 +211,7 @@ class _GoalTile extends StatelessWidget {
           Text(
             goal.label,
             style: AppTextStyles.labelMedium.copyWith(
-              color: isSelected ? goal.color : colors.textPrimary,
+              color: colors.textPrimary,
               fontWeight:
                   isSelected ? FontWeight.w600 : FontWeight.w500,
             ),

--- a/zuralog/lib/features/onboarding/presentation/steps/name_step.dart
+++ b/zuralog/lib/features/onboarding/presentation/steps/name_step.dart
@@ -67,6 +67,8 @@ class _NameStepState extends State<NameStep> {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(
         AppDimens.spaceLg,
@@ -81,7 +83,7 @@ class _NameStepState extends State<NameStep> {
           Text(
             'What should we\ncall you?',
             style: AppTextStyles.displayLarge.copyWith(
-              color: AppColors.primary,
+              color: colors.primary,
               height: 1.1,
             ),
           ),
@@ -89,7 +91,7 @@ class _NameStepState extends State<NameStep> {
           Text(
             'Your AI coach will use this name.',
             style: AppTextStyles.bodyLarge.copyWith(
-              color: AppColors.textSecondaryDark,
+              color: colors.textSecondary,
             ),
           ),
 
@@ -104,7 +106,7 @@ class _NameStepState extends State<NameStep> {
             keyboardType: TextInputType.name,
             textInputAction: TextInputAction.done,
             style: AppTextStyles.titleLarge.copyWith(
-              color: AppColors.textPrimaryDark,
+              color: colors.textPrimary,
             ),
             decoration: InputDecoration(
               hintText: 'Your name or nickname...',
@@ -139,6 +141,7 @@ class _LivePreviewCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
     final greeting = nickname.trim().isEmpty ? 'there' : nickname.trim();
 
     return ZuralogCard(
@@ -150,15 +153,15 @@ class _LivePreviewCard extends StatelessWidget {
           Container(
             width: 28,
             height: 28,
-            decoration: const BoxDecoration(
-              color: AppColors.primary,
+            decoration: BoxDecoration(
+              color: colors.primary,
               shape: BoxShape.circle,
             ),
-            child: const Center(
+            child: Center(
               child: Icon(
                 Icons.smart_toy_rounded,
                 size: 14,
-                color: AppColors.primaryButtonText,
+                color: colors.textOnSage,
               ),
             ),
           ),
@@ -172,7 +175,7 @@ class _LivePreviewCard extends StatelessWidget {
                 Text(
                   'Preview',
                   style: AppTextStyles.labelSmall.copyWith(
-                    color: AppColors.primary,
+                    color: colors.primary,
                     fontWeight: FontWeight.w700,
                     letterSpacing: 0.5,
                   ),
@@ -181,7 +184,7 @@ class _LivePreviewCard extends StatelessWidget {
                 Text(
                   'Hi $greeting, here\'s your morning briefing...',
                   style: AppTextStyles.bodyMedium.copyWith(
-                    color: AppColors.textPrimaryDark,
+                    color: colors.textPrimary,
                   ),
                 ),
               ],

--- a/zuralog/lib/features/onboarding/presentation/steps/notifications_step.dart
+++ b/zuralog/lib/features/onboarding/presentation/steps/notifications_step.dart
@@ -49,6 +49,7 @@ class NotificationsStep extends StatelessWidget {
   }
 
   Future<void> _pickTime(BuildContext context) async {
+    final colors = AppColorsOf(context);
     final picked = await showTimePicker(
       context: context,
       initialTime: morningBriefingTime,
@@ -56,8 +57,8 @@ class NotificationsStep extends StatelessWidget {
         return Theme(
           data: Theme.of(context).copyWith(
             colorScheme: Theme.of(context).colorScheme.copyWith(
-                  primary: AppColors.primary,
-                  onPrimary: AppColors.primaryButtonText,
+                  primary: colors.primary,
+                  onPrimary: colors.textOnSage,
                 ),
           ),
           child: child!,
@@ -69,6 +70,8 @@ class NotificationsStep extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(
         AppDimens.spaceLg,
@@ -83,7 +86,7 @@ class NotificationsStep extends StatelessWidget {
           Text(
             'Stay in the loop',
             style: AppTextStyles.displayLarge.copyWith(
-              color: AppColors.primary,
+              color: colors.primary,
               height: 1.15,
             ),
           ),
@@ -92,7 +95,7 @@ class NotificationsStep extends StatelessWidget {
             'Customise how Zuralog keeps you informed. '
             'You can change these any time in Settings.',
             style: AppTextStyles.bodyLarge
-                .copyWith(color: AppColors.textSecondaryDark),
+                .copyWith(color: colors.textSecondary),
           ),
 
           const SizedBox(height: AppDimens.spaceXl),
@@ -118,7 +121,7 @@ class NotificationsStep extends StatelessWidget {
                           vertical: 4,
                         ),
                       decoration: BoxDecoration(
-                        color: AppColors.primary.withValues(alpha: 0.12),
+                        color: colors.primary.withValues(alpha: 0.12),
                         borderRadius:
                             BorderRadius.circular(AppDimens.shapePill),
                       ),
@@ -128,14 +131,14 @@ class NotificationsStep extends StatelessWidget {
                           Text(
                             _formatTime(morningBriefingTime),
                             style: AppTextStyles.bodySmall.copyWith(
-                              color: AppColors.primary,
+                              color: colors.primary,
                               fontWeight: FontWeight.w600,
                             ),
                           ),
                           const SizedBox(width: 2),
-                          const Icon(
+                          Icon(
                             Icons.edit_rounded,
-                            color: AppColors.primary,
+                            color: colors.primary,
                             size: 12,
                           ),
                         ],
@@ -202,12 +205,14 @@ class _NotificationRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return AnimatedContainer(
       duration: const Duration(milliseconds: 200),
       decoration: BoxDecoration(
         color: isEnabled
             ? iconColor.withValues(alpha: 0.06)
-            : AppColors.surface,
+            : colors.surface,
         borderRadius: BorderRadius.circular(AppDimens.shapeMd),
       ),
       padding: const EdgeInsets.all(AppDimens.spaceMd),
@@ -233,14 +238,14 @@ class _NotificationRow extends StatelessWidget {
                 Text(
                   title,
                   style: AppTextStyles.titleMedium.copyWith(
-                    color: AppColors.textPrimaryDark,
+                    color: colors.textPrimary,
                   ),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   description,
                   style: AppTextStyles.bodyMedium.copyWith(
-                    color: AppColors.textSecondaryDark,
+                    color: colors.textSecondary,
                   ),
                 ),
                 if (trailing != null) ...[

--- a/zuralog/lib/features/onboarding/presentation/steps/persona_step.dart
+++ b/zuralog/lib/features/onboarding/presentation/steps/persona_step.dart
@@ -17,14 +17,14 @@ import 'package:zuralog/shared/widgets/widgets.dart';
 class _Persona {
   const _Persona({
     required this.id,
-    required this.emoji,
+    required this.icon,
     required this.title,
     required this.description,
     required this.accentColor,
   });
 
   final String id;
-  final String emoji;
+  final IconData icon;
   final String title;
   final String description;
 
@@ -35,21 +35,21 @@ class _Persona {
 const List<_Persona> _personas = [
   _Persona(
     id: 'motivator',
-    emoji: '🔥',
+    icon: Icons.local_fire_department_rounded,
     title: 'Motivator',
     description: 'Energetic, upbeat, pushes you to achieve more every day.',
     accentColor: AppColors.categoryActivity,
   ),
   _Persona(
     id: 'analyst',
-    emoji: '📊',
+    icon: Icons.insights_rounded,
     title: 'Analyst',
     description: 'Data-driven, precise, explains the numbers behind your health.',
     accentColor: AppColors.categoryBody,
   ),
   _Persona(
     id: 'coach',
-    emoji: '🧘',
+    icon: Icons.self_improvement_rounded,
     title: 'Coach',
     description: 'Balanced, supportive, focuses on sustainable long-term habits.',
     accentColor: AppColors.categoryWellness,
@@ -217,11 +217,10 @@ class _PersonaCard extends StatelessWidget {
                               : colors.surfaceRaised,
                           shape: BoxShape.circle,
                         ),
-                        child: Center(
-                          child: Text(
-                            persona.emoji,
-                            style: AppTextStyles.bodyLarge.copyWith(fontSize: 22),
-                          ),
+                        child: Icon(
+                          persona.icon,
+                          size: 24,
+                          color: persona.accentColor,
                         ),
                       ),
                       const SizedBox(width: AppDimens.spaceMd),

--- a/zuralog/lib/features/onboarding/presentation/steps/persona_step.dart
+++ b/zuralog/lib/features/onboarding/presentation/steps/persona_step.dart
@@ -81,6 +81,8 @@ class PersonaStep extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(
         AppDimens.spaceLg,
@@ -95,14 +97,14 @@ class PersonaStep extends StatelessWidget {
           Text(
             'Choose your\nAI persona',
             style: AppTextStyles.displayLarge.copyWith(
-              color: AppColors.primary,
+              color: colors.primary,
               height: 1.15,
             ),
           ),
           const SizedBox(height: AppDimens.spaceSm),
           Text(
             'Pick the coaching style that resonates with you.',
-            style: AppTextStyles.bodyLarge.copyWith(color: AppColors.textSecondaryDark),
+            style: AppTextStyles.bodyLarge.copyWith(color: colors.textSecondary),
           ),
 
           const SizedBox(height: AppDimens.spaceXl),
@@ -130,14 +132,14 @@ class PersonaStep extends StatelessWidget {
           Text(
             'Proactivity',
             style: AppTextStyles.titleMedium.copyWith(
-              color: AppColors.textPrimaryDark,
+              color: colors.textPrimary,
             ),
           ),
           const SizedBox(height: AppDimens.spaceXs),
           Text(
             'How often should your AI coach reach out?',
             style: AppTextStyles.bodyMedium.copyWith(
-              color: AppColors.textSecondaryDark,
+              color: colors.textSecondary,
             ),
           ),
           const SizedBox(height: AppDimens.spaceMd),
@@ -149,7 +151,7 @@ class PersonaStep extends StatelessWidget {
             child: Text(
               _proactivityLabel,
               style: AppTextStyles.bodySmall.copyWith(
-                color: AppColors.primary,
+                color: colors.primary,
                 fontWeight: FontWeight.w600,
               ),
             ),
@@ -176,6 +178,8 @@ class _PersonaCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return ZSelectableTile(
       isSelected: isSelected,
       onTap: onTap,
@@ -210,7 +214,7 @@ class _PersonaCard extends StatelessWidget {
                         decoration: BoxDecoration(
                           color: isSelected
                               ? persona.accentColor.withValues(alpha: 0.15)
-                              : AppColors.surfaceRaised,
+                              : colors.surfaceRaised,
                           shape: BoxShape.circle,
                         ),
                         child: Center(
@@ -229,15 +233,15 @@ class _PersonaCard extends StatelessWidget {
                               persona.title,
                               style: AppTextStyles.titleMedium.copyWith(
                                 color: isSelected
-                                    ? AppColors.primary
-                                    : AppColors.textPrimaryDark,
+                                    ? colors.primary
+                                    : colors.textPrimary,
                               ),
                             ),
                             const SizedBox(height: 2),
                             Text(
                               persona.description,
                               style: AppTextStyles.bodyMedium
-                                  .copyWith(color: AppColors.textSecondaryDark),
+                                  .copyWith(color: colors.textSecondary),
                             ),
                           ],
                         ),

--- a/zuralog/lib/features/onboarding/presentation/steps/welcome_step.dart
+++ b/zuralog/lib/features/onboarding/presentation/steps/welcome_step.dart
@@ -125,6 +125,8 @@ class _WelcomeStepState extends State<WelcomeStep>
 
   @override
   Widget build(BuildContext context) {
+    final colors = AppColorsOf(context);
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AppDimens.spaceLg),
       child: Column(
@@ -144,7 +146,7 @@ class _WelcomeStepState extends State<WelcomeStep>
                     children: [
                       Container(
                         decoration: BoxDecoration(
-                          color: AppColors.primary,
+                          color: colors.primary,
                           borderRadius:
                               BorderRadius.circular(AppDimens.shapeLg),
                         ),
@@ -160,8 +162,8 @@ class _WelcomeStepState extends State<WelcomeStep>
                         padding: const EdgeInsets.all(18),
                         child: SvgPicture.asset(
                           AppAssets.logoSvg,
-                          colorFilter: const ColorFilter.mode(
-                            AppColors.primaryButtonText,
+                          colorFilter: ColorFilter.mode(
+                            colors.textOnSage,
                             BlendMode.srcIn,
                           ),
                         ),
@@ -183,7 +185,7 @@ class _WelcomeStepState extends State<WelcomeStep>
               child: Text(
                 'Hi, welcome\nto Zuralog.',
                 style: AppTextStyles.displayLarge.copyWith(
-                  color: AppColors.primary,
+                  color: colors.primary,
                   height: 1.1,
                 ),
               ),
@@ -200,7 +202,7 @@ class _WelcomeStepState extends State<WelcomeStep>
               child: Text(
                 "Let's set up your AI health coach.",
                 style: AppTextStyles.bodyLarge.copyWith(
-                  color: AppColors.textSecondaryDark,
+                  color: colors.textSecondary,
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- Replace all hardcoded dark-mode colors with theme-aware `AppColorsOf(context)` across all 9 onboarding files
- Headings: forest green in light mode, sage in dark mode (per brand bible)
- Tile/icon backgrounds use correct surface tokens for each theme
- Animated brand pattern overlay with slow diagonal drift on the onboarding flow
- Fixed connect apps tile overflow (aspect ratio 1.0 → 0.9)

## Test plan
- [x] Verified all 8 onboarding steps render correctly in light mode
- [x] Confirmed pattern animation drifts smoothly on the onboarding background
- [x] No overflow errors on connect apps grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)