### PR TITLE
fix(onboarding): remove nickname from preferences PATCH body

### DIFF
--- a/zuralog/lib/features/onboarding/presentation/onboarding_flow_screen.dart
+++ b/zuralog/lib/features/onboarding/presentation/onboarding_flow_screen.dart
@@ -321,10 +321,6 @@ class _OnboardingFlowScreenState extends ConsumerState<OnboardingFlowScreen> {
         body['fitness_level'] = _fitnessLevel;
       }
 
-      if (_nickname.isNotEmpty) {
-        body['nickname'] = _nickname;
-      }
-
       await apiClient.patch('/api/v1/preferences', body: body);
 
       // PostHog completion events


### PR DESCRIPTION
## Summary
- Remove `nickname` from the preferences PATCH request body — it doesn't exist on the `PreferencesUpdate` Pydantic model, causing a validation error that blocks onboarding completion
- Nickname is already correctly sent via the profile update call (`UserProfileNotifier.update`) that runs immediately after

## Test plan
- [x] Complete onboarding flow end-to-end without "Failed to save preferences" error
- [x] Verify nickname is still saved via the profile update

🤖 Generated with [Claude Code](https://claude.com/claude-code)